### PR TITLE
Minor fixes to make it easy to run locally.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+**/__pycache__/
+langchain.readthedocs.io

--- a/README.md
+++ b/README.md
@@ -30,3 +30,34 @@ Question-Answering has the following steps:
 ## 🧠 How to Extend to your documentation?
 
 Coming soon.
+
+
+## How To Deploy It Yourself
+
+1. Create a weaviate cluster on https://weaviate.io/
+
+   * You can use a free sandbox cluster
+
+1. Set the environment variable for WEAVIATE
+
+   ```
+   export WEAVIATE_URL=https://${NAME}.weaviate.network 
+   ```
+
+1. Set the environment variable for your OPENAI Key
+
+   ```
+   export OPENAI_API_KEY
+   ```
+
+1. Run the ingestion script
+
+   ```
+   ingest.sh
+   ```
+
+1. Start the local server
+
+   ```
+   python3 app.py 
+   ```

--- a/ingest.py
+++ b/ingest.py
@@ -5,7 +5,9 @@ from pathlib import Path
 import weaviate
 from bs4 import BeautifulSoup
 from langchain.text_splitter import CharacterTextSplitter
+import logging
 
+logging.basicConfig(level=logging.INFO)
 
 def clean_data(data):
     soup = BeautifulSoup(data)
@@ -39,7 +41,15 @@ client = weaviate.Client(
     additional_headers={"X-OpenAI-Api-Key": os.environ["OPENAI_API_KEY"]},
 )
 
-client.schema.delete_class("Paragraph")
+try:
+    client.schema.delete_class("Paragraph")
+except weaviate.exceptions.UnexpectedStatusCodeException as e:
+    if e.status_code == 400:
+        # If this is the first time running this script, the class does not exist yet.
+        logging.info("Class Paragraph does not exist yet.")
+    else:
+        raise
+
 client.schema.get()
 schema = {
     "classes": [

--- a/ingest.sh
+++ b/ingest.sh
@@ -1,6 +1,10 @@
 # Bash script to ingest data
 # This involves scraping the data from the web and then cleaning up and putting in Weaviate.
-!set -eu
-wget -r -A.html https://langchain.readthedocs.io/en/latest/
+set -eu
+
+if [ ! -d langchain.readthedocs.io ]; then
+	echo downloading docs
+	wget -r -A.html https://langchain.readthedocs.io/en/latest/
+fi	
 python3 ingest.py
 python3 ingest_examples.py


### PR DESCRIPTION
This is an unsolicited PR so feel free to close. Happy to make revisions as well. This PR fixes a couple minor issues I ran into while attempting to run the chatbot to use for my own purposes. 

* ingest.py and ingest_examples.py raise an exception trying to delete the schemas

  * Catch these exceptions and keep going
  * My guess is the code was written as though the schemas had already been created and therefore wants to recreate them
  * This causes the aforementioned exceptions when starting with a fresh weaviate cluster

* Here's an example exception

  Traceback (most recent call last): File "/Users/jlewi/git_chat-langchain/ingest.py", line 42, in <module> client.schema.delete_class("Paragraph") File "/opt/homebrew/lib/python3.10/site-packages/weaviate/schema/crud_schema.py", line 201, in delete_class raise UnexpectedStatusCodeException("Delete class from schema", response) weaviate.exceptions.UnexpectedStatusCodeException: Delete class from schema! Unexpected status code: 400, with response body: {'error': [{'message': "could not find class 'Paragraph'"}]}.

* Update ingest.sh to check if the documents have already been downloaded.
* Update the README.md with instructions about how to deploy it yourself.

* Add a .gitignore file