### PR TITLE
Temporary Fix for Issue #27

### DIFF
--- a/query_data.py
+++ b/query_data.py
@@ -1,7 +1,7 @@
-"""Create a ChatVectorDBChain for question/answering."""
+"""Create a ConversationalRetrievalChain for question/answering."""
 from langchain.callbacks.base import AsyncCallbackManager
 from langchain.callbacks.tracers import LangChainTracer
-from langchain.chains import ChatVectorDBChain
+from langchain.chains import ConversationalRetrievalChain
 from langchain.chains.chat_vector_db.prompts import (CONDENSE_QUESTION_PROMPT,
                                                      QA_PROMPT)
 from langchain.chains.llm import LLMChain
@@ -12,9 +12,9 @@ from langchain.vectorstores.base import VectorStore
 
 def get_chain(
     vectorstore: VectorStore, question_handler, stream_handler, tracing: bool = False
-) -> ChatVectorDBChain:
-    """Create a ChatVectorDBChain for question/answering."""
-    # Construct a ChatVectorDBChain with a streaming llm for combine docs
+) -> ConversationalRetrievalChain:
+    """Create a ConversationalRetrievalChain for question/answering."""
+    # Construct a ConversationalRetrievalChain with a streaming llm for combine docs
     # and a separate, non-streaming llm for question generation
     manager = AsyncCallbackManager([])
     question_manager = AsyncCallbackManager([question_handler])
@@ -45,8 +45,8 @@ def get_chain(
         streaming_llm, chain_type="stuff", prompt=QA_PROMPT, callback_manager=manager
     )
 
-    qa = ChatVectorDBChain(
-        vectorstore=vectorstore,
+    qa = ConversationalRetrievalChain(
+        retriever=vectorstore.as_retriever(),
         combine_docs_chain=doc_chain,
         question_generator=question_generator,
         callback_manager=manager,

--- a/query_data.py
+++ b/query_data.py
@@ -7,8 +7,15 @@ from langchain.chains.chat_vector_db.prompts import (CONDENSE_QUESTION_PROMPT,
 from langchain.chains.llm import LLMChain
 from langchain.chains.question_answering import load_qa_chain
 from langchain.llms import OpenAI
-from langchain.vectorstores.base import VectorStore
+from langchain.vectorstores.base import VectorStore, VectorStoreRetriever
 
+from langchain.schema import Document
+from typing import List
+
+async def aget_relevant_documents(self, query: str) -> List[Document]:
+    return self.get_relevant_documents(query)
+
+VectorStoreRetriever.aget_relevant_documents = aget_relevant_documents
 
 def get_chain(
     vectorstore: VectorStore, question_handler, stream_handler, tracing: bool = False


### PR DESCRIPTION
This fixes https://github.com/hwchase17/chat-langchain/issues/44 by monkey patching the `VectorStoreRetriever` class.

Also included in this PR is https://github.com/hwchase17/chat-langchain/pull/43/commits/3947f88f9f83732e345f28fe19f9ad0e20b49f2d to use `ConversationalRetrievalChain` instead of `ChatVectorDBChain` 

Once the underlying issue is fixed: https://github.com/hwchase17/langchain/issues/2268 then my commit could just be reverted, but at least this gets the example up and running.