### PR TITLE
fix: Replace ReadTheDocsLoader with UnstructuredURLLoader

### DIFF
--- a/ingest.py
+++ b/ingest.py
@@ -5,11 +5,11 @@ from langchain.document_loaders import ReadTheDocsLoader
 from langchain.embeddings import OpenAIEmbeddings
 from langchain.text_splitter import RecursiveCharacterTextSplitter
 from langchain.vectorstores.faiss import FAISS
-
+from langchain.document_loaders import UnstructuredURLLoader
 
 def ingest_docs():
     """Get documents from web pages."""
-    loader = ReadTheDocsLoader("langchain.readthedocs.io/en/latest/")
+    loader = UnstructuredURLLoader(urls=["https://python.langchain.com/en/latest/"])
     raw_documents = loader.load()
     text_splitter = RecursiveCharacterTextSplitter(
         chunk_size=1000,


### PR DESCRIPTION
This fixes https://github.com/hwchase17/chat-langchain/issues/26 as suggested by @jeru2023