### PR TITLE
fixes: "langchain.readthedocs.io" -> "python.langchain.com", else it only downloads a single index.html

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,4 @@ dmypy.json
 
 vectorstore.pkl
 langchain.readthedocs.io/
+python.langchain.com/

--- a/ingest.bat
+++ b/ingest.bat
@@ -1,0 +1,7 @@
+@echo off
+rem Batch script to ingest data
+rem This involves scraping the data from the web and then cleaning up and putting in Weaviate.
+wget -r -A.html https://python.langchain.com/en/latest/
+if %errorlevel% neq 0 exit /b %errorlevel%
+python3 ingest.py
+if %errorlevel% neq 0 exit /b %errorlevel%

--- a/ingest.py
+++ b/ingest.py
@@ -9,7 +9,7 @@ from langchain.vectorstores.faiss import FAISS
 
 def ingest_docs():
     """Get documents from web pages."""
-    loader = ReadTheDocsLoader("langchain.readthedocs.io/en/latest/")
+    loader = ReadTheDocsLoader("python.langchain.com/en/latest/")
     raw_documents = loader.load()
     text_splitter = RecursiveCharacterTextSplitter(
         chunk_size=1000,

--- a/ingest.sh
+++ b/ingest.sh
@@ -2,5 +2,5 @@
 # This involves scraping the data from the web and then cleaning up and putting in Weaviate.
 # Error if any command fails
 set -e
-wget -r -A.html https://langchain.readthedocs.io/en/latest/
+wget -r -A.html https://python.langchain.com/en/latest/
 python3 ingest.py


### PR DESCRIPTION
The current ingest wget command only downloads a single index.html file, I noticed that "https://langchain.readthedocs.io/en/latest/" redirects to "https://python.langchain.com/en/latest/" and when I change the script to use the second url it downloads correctly everything recursively. Is the wget command used wrongly, or perhaps did the documentation link change and the script is outdated?

Anyways now it scrapes the docs correctly.
Extra: +ingest.bat for us windows scrubs.