### PR TITLE
Update query_data.py

### DIFF
--- a/query_data.py
+++ b/query_data.py
@@ -1,7 +1,7 @@
-"""Create a ChatVectorDBChain for question/answering."""
-from langchain.callbacks.base import AsyncCallbackManager
+"""Create a ConversationalRetrievalChain for question/answering."""
+from langchain.callbacks.manager import AsyncCallbackManager
 from langchain.callbacks.tracers import LangChainTracer
-from langchain.chains import ChatVectorDBChain
+from langchain.chains import ConversationalRetrievalChain
 from langchain.chains.chat_vector_db.prompts import (CONDENSE_QUESTION_PROMPT,
                                                      QA_PROMPT)
 from langchain.chains.llm import LLMChain
@@ -12,9 +12,9 @@ from langchain.vectorstores.base import VectorStore
 
 def get_chain(
     vectorstore: VectorStore, question_handler, stream_handler, tracing: bool = False
-) -> ChatVectorDBChain:
-    """Create a ChatVectorDBChain for question/answering."""
-    # Construct a ChatVectorDBChain with a streaming llm for combine docs
+) -> ConversationalRetrievalChain:
+    """Create a ConversationalRetrievalChain for question/answering."""
+    # Construct a ConversationalRetrievalChain with a streaming llm for combine docs
     # and a separate, non-streaming llm for question generation
     manager = AsyncCallbackManager([])
     question_manager = AsyncCallbackManager([question_handler])
@@ -45,10 +45,11 @@ def get_chain(
         streaming_llm, chain_type="stuff", prompt=QA_PROMPT, callback_manager=manager
     )
 
-    qa = ChatVectorDBChain(
-        vectorstore=vectorstore,
+    qa = ConversationalRetrievalChain(
+        vectorstore=vectorstore.as_retriever(),
         combine_docs_chain=doc_chain,
         question_generator=question_generator,
         callback_manager=manager,
+        return_source_documents=True
     )
     return qa


### PR DESCRIPTION
This PR fixes two breaking changes recently introduced in `hwchase17/langchain`:

1. `ConversationalRetrievalChain` replacing `ChatVectorDBChain` per [this blog](https://blog.langchain.dev/retrieval/)  
2. `AsyncCallbackManager` moved to `langchain.callbacks.manager` after [this refactor](https://github.com/hwchase17/langchain/commit/d3ec00b5664798be74daa9bdc28ae7c2c86ee22e#diff-6963566c770da898dfa2ac70ceeb845afbcf4aa01009e566a43a3588398de989R572)