### PR TITLE
Update README.md with the updated link to Document Loaders

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The app leverages LangChain's streaming support and async API to update the page
 ## ✅ Running locally
 1. Install dependencies: `pip install -r requirements.txt`
 1. Run `ingest.sh` to ingest LangChain docs data into the vectorstore (only needs to be done once).
-   1. You can use other [Document Loaders](https://langchain.readthedocs.io/en/latest/modules/document_loaders.html) to load your own data into the vectorstore.
+   1. You can use other [Document Loaders](https://python.langchain.com/en/latest/reference/modules/document_loaders.html) to load your own data into the vectorstore.
 1. Run the app: `make start`
    1. To enable tracing, make sure `langchain-server` is running locally and pass `tracing=True` to `get_chain` in `main.py`. You can find more documentation [here](https://langchain.readthedocs.io/en/latest/tracing.html).
 1. Open [localhost:9000](http://localhost:9000) in your browser.


### PR DESCRIPTION
The current link to "document loaders" doesn't work anymore. Here the updated link